### PR TITLE
Remove parent_pset concept

### DIFF
--- a/app/features/course/tools.rb
+++ b/app/features/course/tools.rb
@@ -43,18 +43,6 @@ class Course::Tools
 		# check if any grades are "tests" (for easy data entry on exams), sets flag
 		Settings['tests_present'] = Pset.where(test:true).any?
 		
-		# PSET MODULES
-		# check all module definitions, connect psets to parent psets
-		if Settings['grading'] && Settings['grading']['modules']
-			Settings['grading']['modules'].each do |name, psets|
-				parent_pset = Pset.where(name: name).first_or_create
-				psets.each do |pset_name|
-					pset = Pset.find_by_name(pset_name)
-					pset.update(parent_pset: parent_pset)
-				end
-			end
-		end
-
 	end
 	
 end

--- a/app/models/pset.rb
+++ b/app/models/pset.rb
@@ -2,7 +2,6 @@ class Pset < ApplicationRecord
 
 	belongs_to :page, optional: true
 	
-	belongs_to :parent_pset, :class_name => 'Pset', optional: true
 	has_many :child_psets, :class_name => 'Pset', :foreign_key => 'parent_pset_id'
 
 	has_many :pset_files

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,7 +80,7 @@ class User < ApplicationRecord
 	def items(with_private=false)
 		items = []
 		# show all submits for psets that are _not_ a module
-		items += submits.includes({:pset => [:parent_pset, :child_psets]}).where("submitted_at is not null").where("child_psets_psets.id is null or parent_psets_psets.id is not null").references(:parent_pset, :child_psets).to_a
+		items += submits.where("submitted_at is not null").to_a
 		items += grades.includes(:pset, :submit, :grader).showable.to_a
 		items += hands.includes(:assist).to_a if with_private
 		items += notes.includes(:author).to_a if with_private


### PR DESCRIPTION
- When submitting, a submit will not automatically be made/updated for the module
- Module psets will still have child psets which will be shown during grading
